### PR TITLE
Improve positioning of images on industry cards

### DIFF
--- a/core/sass/pages/industries-landing-page.scss
+++ b/core/sass/pages/industries-landing-page.scss
@@ -14,10 +14,23 @@ a.labelled-card {
   img {
     max-height: 150px;
     object-fit: cover;
+    object-position: 80%;
     width: auto;
   }
 
   .card-inner {
     display: none;
+  }
+}
+
+@media (max-width: 960px) {
+  .column-third {
+    width: 50%;
+  }
+}
+
+@media (max-width: 640px) {
+  .column-third {
+    width: 100%;
   }
 }

--- a/core/static/styles/pages/industries-landing-page.css
+++ b/core/static/styles/pages/industries-landing-page.css
@@ -1,3 +1,3 @@
-.industries{padding-top:60px}a.labelled-card{min-height:auto}a.labelled-card img{max-height:150px;object-fit:cover;width:auto}a.labelled-card .card-inner{display:none}
+.industries{padding-top:60px}a.labelled-card{min-height:auto}a.labelled-card img{max-height:150px;object-fit:cover;object-position:80%;width:auto}a.labelled-card .card-inner{display:none}@media (max-width: 960px){.column-third{width:50%}}@media (max-width: 640px){.column-third{width:100%}}
 
 /*# sourceMappingURL=../maps/pages/industries-landing-page.css.map */


### PR DESCRIPTION
https://uktrade.atlassian.net/browse/CMS-246

![screencapture-localhost-8012-industries-2018-07-05-12_44_52](https://user-images.githubusercontent.com/25905279/42321604-7b28a820-8051-11e8-8868-40c526c59177.jpg)
![screencapture-localhost-8012-industries-2018-07-05-12_45_07](https://user-images.githubusercontent.com/25905279/42321605-7b416db0-8051-11e8-8bdc-cf0f2f299c36.jpg)

- Align images to the right since focal points are on the right
- Collapse to 2 columns on medium screens