### PR TITLE
Fix name of portuguese language in settings

### DIFF
--- a/conf/settings.py
+++ b/conf/settings.py
@@ -143,7 +143,7 @@ LANGUAGES = [
     ('zh-hans', '简体中文'),             # Simplified Chinese
     ('fr', 'Français'),                 # French
     ('es', 'español'),                  # Spanish
-    ('pt', 'Português Brasileiro'),  # Portuguese (Brazilian)
+    ('pt', 'Português'),                # Portuguese
     ('ar', 'العربيّة'),                 # Arabic
     # ('ru', 'Русский'),                  # Russian
 ]


### PR DESCRIPTION
https://uktrade.atlassian.net/browse/CMS-484