### PR TITLE
Remove autocomplete from contact form

### DIFF
--- a/contact/forms.py
+++ b/contact/forms.py
@@ -318,7 +318,7 @@ class ContactForm(forms.Form):
         help_text=_(
             'We will use this information to put you in touch with '
             'your closest British embassy or high commission.'),
-        choices=COUNTRIES,
+        choices=(('', ''),) + COUNTRIES,
         widget=Select(attrs={'id': 'js-country-select'})
     )
     staff_number = fields.ChoiceField(

--- a/contact/templates/contact/contact.html
+++ b/contact/templates/contact/contact.html
@@ -48,17 +48,3 @@
 </div>
 
 {% endblock %}
-
-
-{% block body_js %}
-  <script src="{% static 'js/vendor/accessible-autocomplete.min.js' %}"></script>
-  <script>
-    accessibleAutocomplete.enhanceSelectElement({
-      selectElement: document.getElementById('js-country-select'),
-      defaultValue: '',
-      autoselect: false,
-      showAllValues: false,
-      minLength: 1
-    })
-  </script>
-{% endblock %}


### PR DESCRIPTION
users were confused by the field and submitting afganistan.

as we do not have the translated content for "start typing here" we just show a dropdown with blank value

![image](https://user-images.githubusercontent.com/5485798/46159348-01fcaa00-c278-11e8-85e7-80b6c6bdd748.png)
