### PR TITLE
Fix previewing of pages that include a CMS component

### DIFF
--- a/core/mixins.py
+++ b/core/mixins.py
@@ -59,7 +59,6 @@ class GetCMSComponentMixin:
         response = cms_api_client.lookup_by_slug(
             slug=self.component_slug,
             language_code=translation.get_language(),
-            draft_token=self.request.GET.get('draft_token'),
             service_name=cms.COMPONENTS,
         )
         return handle_cms_response_allow_404(response)


### PR DESCRIPTION
Don't supply `draft_token` when requesting CMS component details from the API. If present, the token corresponds to the actual page being previewed, and not the component page.