### PR TITLE
Added emtpy string fallback for required UTM fields

### DIFF
--- a/opportunities/forms.py
+++ b/opportunities/forms.py
@@ -17,6 +17,13 @@ class HighPotentialOpportunityForm(forms.Form):
         ('51 - 250', '51 - 250'),
         ('250+', '250+'),
     ]
+    REQUIRED_UTM_FIELD_NAMES = (
+        'utm_source',
+        'utm_medium',
+        'utm_campaign',
+        'utm_term',
+        'utm_content',
+    )
 
     def __init__(
         self, field_attributes, opportunity_choices,
@@ -73,6 +80,11 @@ class HighPotentialOpportunityForm(forms.Form):
             for item in self.base_fields['opportunities'].choices
             if item[0] in self.cleaned_data['opportunities']
         ]
+
+        # set empty string not exists data fields
+        for f in self.REQUIRED_UTM_FIELD_NAMES:
+            if f not in self.utm_data.keys():
+                self.utm_data[f] = ''
 
         return {
             **self.cleaned_data,

--- a/opportunities/tests/test_forms.py
+++ b/opportunities/tests/test_forms.py
@@ -56,11 +56,11 @@ def test_high_potential_opportunity_form_serialize_data(captcha_stub):
             ('http://www.e.com/b', 'some other great opportunity'),
         ],
         utm_data={
-            'campaign_source': 'test_source',
-            'campaign_medium': 'test_medium',
-            'campaign_name': 'test_campaign',
-            'campaign_term': 'test_term',
-            'campaign_content': 'test_content'
+            'utm_source': 'test_source',
+            'utm_medium': 'test_medium',
+            'utm_campaign': 'test_campaign',
+            'utm_term': 'test_term',
+            'utm_content': 'test_content'
         }
     )
 
@@ -86,10 +86,67 @@ def test_high_potential_opportunity_form_serialize_data(captcha_stub):
         'comment': 'hello',
         'terms_agreed': True,
         'utm_data': {
-            'campaign_source': 'test_source',
-            'campaign_medium': 'test_medium',
-            'campaign_name': 'test_campaign',
-            'campaign_term': 'test_term',
-            'campaign_content': 'test_content'
+            'utm_source': 'test_source',
+            'utm_medium': 'test_medium',
+            'utm_campaign': 'test_campaign',
+            'utm_term': 'test_term',
+            'utm_content': 'test_content'
+        }
+    }
+
+
+def test_hpo_form_serialize_data_without_utm_data(captcha_stub):
+    form = forms.HighPotentialOpportunityForm(
+        data={
+            'full_name': 'Jim Example',
+            'role_in_company': 'Chief chief',
+            'email_address': 'test@example.com',
+            'phone_number': '555',
+            'company_name': 'Example corp',
+            'website_url': 'example.com',
+            'country': choices.COUNTRY_CHOICES[1][0],
+            'company_size': '1 - 10',
+            'opportunities': [
+                'http://www.e.com/a',
+                'http://www.e.com/b',
+            ],
+            'comment': 'hello',
+            'terms_agreed': True,
+            'g-recaptcha-response': captcha_stub,
+        },
+        field_attributes={},
+        opportunity_choices=[
+            ('http://www.e.com/a', 'some great opportunity'),
+            ('http://www.e.com/b', 'some other great opportunity'),
+        ],
+    )
+
+    assert form.is_valid()
+    assert form.serialized_data == {
+        'full_name': 'Jim Example',
+        'role_in_company': 'Chief chief',
+        'email_address': 'test@example.com',
+        'phone_number': '555',
+        'captcha': 'PASSED',
+        'company_name': 'Example corp',
+        'website_url': 'example.com',
+        'country': choices.COUNTRY_CHOICES[1][0],
+        'company_size': '1 - 10',
+        'opportunities': [
+            'http://www.e.com/a',
+            'http://www.e.com/b',
+        ],
+        'opportunity_urls': (
+            '• some great opportunity: http://www.e.com/a\n'
+            '• some other great opportunity: http://www.e.com/b'
+        ),
+        'comment': 'hello',
+        'terms_agreed': True,
+        'utm_data': {
+            'utm_source': '',
+            'utm_medium': '',
+            'utm_campaign': '',
+            'utm_term': '',
+            'utm_content': ''
         }
     }


### PR DESCRIPTION
It is a patch PR for #162 

Gov notify email template engine doesn't support if exists logic so I am passing empty string if any required field is doesn't exist. 

https://uktrade.atlassian.net/browse/XOT-819