### PR TITLE
Changed UTM DATA format on HPO form serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 
 ### Fixed bugs:
 - Upgraded urllib3 to fix [vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2019-11324)
+- Changed HPO contact form data serialization format.([XOT-819](https://uktrade.atlassian.net/browse/XOT-819))
 
 
 [directory-client-core]: https://github.com/uktrade/directory-client-core

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Fixed bugs:
 
 - [[CMS-1395]](https://uktrade.atlassian.net/browse/CMS-1395) Fix language cookie name and domain to be the same across all our services.
+- [XOT-819](https://uktrade.atlassian.net/browse/XOT-819) Changed HPO contact form data serialization format.
 
 ## [2019.04.30](https://github.com/uktrade/invest-ui/releases/tag/2019.04.30)
 [Full Changelog](https://github.com/uktrade/invest-ui/compare/2019.04.24...2019.04.30)
@@ -42,7 +43,6 @@
 
 ### Fixed bugs:
 - Upgraded urllib3 to fix [vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2019-11324)
-- Changed HPO contact form data serialization format.([XOT-819](https://uktrade.atlassian.net/browse/XOT-819))
 
 
 [directory-client-core]: https://github.com/uktrade/directory-client-core

--- a/makefile
+++ b/makefile
@@ -72,7 +72,7 @@ debug_webserver:
 	$(DEBUG_SET_ENV_VARS) && $(DJANGO_WEBSERVER)
 
 debug_pytest:
-	$(DEBUG_SET_ENV_VARS) && $(COLLECT_STATIC) && $(PYTEST)
+	$(DEBUG_SET_ENV_VARS) && $(COLLECT_STATIC) && pytest opportunities/tests
 
 debug_test:
 	$(DEBUG_SET_ENV_VARS) && $(TEST_SET_ENV_VARS) && $(COLLECT_STATIC) && $(PYTEST) --cov-report=html

--- a/opportunities/forms.py
+++ b/opportunities/forms.py
@@ -83,12 +83,11 @@ class HighPotentialOpportunityForm(forms.Form):
             for item in self.base_fields['opportunities'].choices
             if item[0] in self.cleaned_data['opportunities']
         ]
-        serialized_data = {
+        return {
             **self.cleaned_data,
+            **self.utm_data,
             'opportunity_urls': '\n'.join(formatted_opportunities),
         }
-        serialized_data.update(self.utm_data)
-        return serialized_data
 
     def send_agent_email(self, form_url):
         sender = Sender(

--- a/opportunities/forms.py
+++ b/opportunities/forms.py
@@ -83,11 +83,12 @@ class HighPotentialOpportunityForm(forms.Form):
             for item in self.base_fields['opportunities'].choices
             if item[0] in self.cleaned_data['opportunities']
         ]
-        return {
+        serialized_data = {
             **self.cleaned_data,
             'opportunity_urls': '\n'.join(formatted_opportunities),
-            'utm_data': self.utm_data
         }
+        serialized_data.update(self.utm_data)
+        return serialized_data
 
     def send_agent_email(self, form_url):
         sender = Sender(

--- a/opportunities/tests/test_forms.py
+++ b/opportunities/tests/test_forms.py
@@ -85,13 +85,11 @@ def test_high_potential_opportunity_form_serialize_data(captcha_stub):
         ),
         'comment': 'hello',
         'terms_agreed': True,
-        'utm_data': {
-            'utm_source': 'test_source',
-            'utm_medium': 'test_medium',
-            'utm_campaign': 'test_campaign',
-            'utm_term': 'test_term',
-            'utm_content': 'test_content'
-        }
+        'utm_source': 'test_source',
+        'utm_medium': 'test_medium',
+        'utm_campaign': 'test_campaign',
+        'utm_term': 'test_term',
+        'utm_content': 'test_content'
     }
 
 
@@ -142,11 +140,9 @@ def test_hpo_form_serialize_data_without_utm_data(captcha_stub):
         ),
         'comment': 'hello',
         'terms_agreed': True,
-        'utm_data': {
-            'utm_source': '',
-            'utm_medium': '',
-            'utm_campaign': '',
-            'utm_term': '',
-            'utm_content': ''
-        }
+        'utm_source': '',
+        'utm_medium': '',
+        'utm_campaign': '',
+        'utm_term': '',
+        'utm_content': ''
     }


### PR DESCRIPTION
The government notification API email template format doesn't support the data collections. So I changed the data format for each value to a string. 