### PR TITLE
CI-108: Turn off custom tags for GA temporarily.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Pre-release
 
 ### Implemented Enhancements
-
+- [CI-108](https://uktrade.atlassian.net/browse/CI-108) Temporarily Turn off the new custom tags and events for GA 360.
 
 ## [2019.05.09](https://github.com/uktrade/invest-ui/releases/tag/2019.05.09)
 [Full Changelog](https://github.com/uktrade/invest-ui/compare/2019.04.30...2019.05.09)

--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -67,19 +67,6 @@
           <script src="{% static 'directory_components/js/dit.components.greatInternationalHeader.js' %}"></script>
         {% endblock %}
 
-        {% block head_js_ga360 %}
-            <script type="text/javascript"> window.dataLayer = window.dataLayer || [];</script>
-            {% if ga360 %}
-                <script src="{% static 'js/dit.tagging.js' %}"></script>
-                <script src="{% static 'directory_components/js/dit.tagging.internationalHeader.js' %}"></script>
-                <script id="ga360-script">
-                    window.dataLayer.push({ 'pageCategory': '{{ ga360.page_type }}' });
-                    dit.tagging.invest.init('{{ ga360.page_type }}');
-                    dit.tagging.internationalHeader.init();
-                </script>
-            {% endif %}
-        {% endblock %}
-
         {% block head_other %}{% endblock %}
 
         {% block head_sharing_metadata %}


### PR DESCRIPTION
The spec for the data to be sent in these tags has been changed.
We don't have time to update and test the changes before release, so we are temporarily turning off this feature in preference to sending incorrect and potentially confusing data.

General GA data (eg tracking of the URLs that that user visits) will not be affected by this commit and will continue to send as normal.